### PR TITLE
poc, log only one error when robot is offline instead spaming permanent

### DIFF
--- a/src/romy/utils.py
+++ b/src/romy/utils.py
@@ -13,21 +13,22 @@ else:
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_query(host: str, port: int, command: str, timeout: int = 3) -> tuple[bool, str]:
+async def async_query(host: str, port: int, command: str, timeout: int = 3, error_log_level : int = logging.ERROR) -> tuple[bool, str]:
     """Call function to Send a http query."""
-    ret, resp, _ = await _async_query(host, port, command, timeout)
+    ret, resp, _ = await _async_query(host, port, command, timeout, error_log_level)
     return ret, resp
 
 
-async def async_query_with_http_status(host: str, port: int, command: str, timeout: int = 3) -> tuple[bool, str, int]:
+async def async_query_with_http_status(host: str, port: int, command: str, timeout: int = 3, error_log_level : int = logging.ERROR) -> tuple[bool, str, int]:
     """Call function to Send a http query which returns http status code additionally."""
-    ret, resp, http_status = await _async_query(host, port, command, timeout)
+    ret, resp, http_status = await _async_query(host, port, command, timeout, error_log_level)
     return ret, resp, http_status
 
 
-async def _async_query(host: str, port: int, command: str, timeout: int) -> tuple[bool, str, int]:
+async def _async_query(host: str, port: int, command: str, timeout: int, error_log_level : int) -> tuple[bool, str, int]:
     """Send a http query."""
-    _LOGGER.debug("async_query host=%s, port=%s, command=%s", host, port, command)
+
+    _LOGGER.debug("async_query host=%s, port=%s, command=%s error_log_level=%s", host, port, command, error_log_level)
     try:
         #websession = async_get_clientsession(hass)
         async with aiohttp.ClientSession() as websession:
@@ -48,9 +49,9 @@ async def _async_query(host: str, port: int, command: str, timeout: int) -> tupl
                 return ret, response_decoded, webresponse.status
 
     except asyncio.TimeoutError:
-        _LOGGER.warning("ROMY robot timed out")
+        _LOGGER.log(error_log_level, "ROMY robot timed out")
         return False, "timeout", 0
     except aiohttp.ClientError as error:
-        _LOGGER.warning("Error getting ROMY robot data: %s", error)
+        _LOGGER.log(error_log_level, "Error getting ROMY robot data: %s", error)
         return False, str(error), 0
 


### PR DESCRIPTION
avoids spaming erros permanently when robot is offline

you can test it with:

change version to 0.0.9
homeassistant/components/romy/manifest.json

in pypi romy volder:
####################
python -m build
pip install ./dist/romy-0.0.9-py3-none-any.whl --force-reinstall

in HA core folder:
###################
source venv/bin/activate
hass -c config


